### PR TITLE
Completely left align the time

### DIFF
--- a/plugins/date-and-time/index.tsx
+++ b/plugins/date-and-time/index.tsx
@@ -47,7 +47,7 @@ class Time extends React.Component {
 
   render() {
     return (
-      <div style={{ textAlign: 'center' }}>
+      <div style={{ textAlign: 'left' }}>
         <StyledTime>{this.state.time}</StyledTime>
         <StyledDate>{this.state.formattedDate}</StyledDate>
       </div>


### PR DESCRIPTION
It looks better (See screenshots). From a designer standpoint, it makes more sense for it to be completely left aligned. This should also be changeable later in settings.
![image](https://user-images.githubusercontent.com/24457862/109405539-35efc400-7937-11eb-9526-f76f27a1ebfa.png)
